### PR TITLE
Team Deathmatch Working Build

### DIFF
--- a/Twisted Sails/Assets/Prefabs/Canvas(Health).prefab
+++ b/Twisted Sails/Assets/Prefabs/Canvas(Health).prefab
@@ -28,6 +28,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000010370936638
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000012246945104}
+  - 222: {fileID: 222000013790490338}
+  - 114: {fileID: 114000012333502436}
+  m_Layer: 5
+  m_Name: YouWin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
 --- !u!1 &1000010457323918
 GameObject:
   m_ObjectHideFlags: 1
@@ -45,6 +62,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000010460621602
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000012818607692}
+  - 222: {fileID: 222000010265003894}
+  - 114: {fileID: 114000012688573902}
+  m_Layer: 5
+  m_Name: RedTeamWins
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
 --- !u!1 &1000010508589270
 GameObject:
   m_ObjectHideFlags: 1
@@ -55,6 +89,40 @@ GameObject:
   - 224: {fileID: 224000010940457322}
   m_Layer: 5
   m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1000010537398346
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000013326558556}
+  - 222: {fileID: 222000013163494462}
+  - 114: {fileID: 114000014272157998}
+  m_Layer: 5
+  m_Name: YouLose
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!1 &1000010728149296
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000011313589806}
+  - 222: {fileID: 222000011712506642}
+  - 114: {fileID: 114000010434038904}
+  m_Layer: 5
+  m_Name: FinalScore
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -212,6 +280,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000011983675010
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000012321135810}
+  - 222: {fileID: 222000013155161784}
+  - 114: {fileID: 114000010336469126}
+  m_Layer: 5
+  m_Name: BlueTeamWins
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
 --- !u!1 &1000012040822448
 GameObject:
   m_ObjectHideFlags: 1
@@ -229,6 +314,24 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000012163253234
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000013531459410}
+  - 222: {fileID: 222000012413296608}
+  - 114: {fileID: 114000011718831702}
+  - 114: {fileID: 114000013519517360}
+  m_Layer: 5
+  m_Name: Hurt Self
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
 --- !u!1 &1000012240392530
 GameObject:
   m_ObjectHideFlags: 1
@@ -240,6 +343,23 @@ GameObject:
   - 114: {fileID: 114000013370114020}
   m_Layer: 5
   m_Name: SpeedBar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1000012621375146
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000010825151130}
+  - 222: {fileID: 222000011789448334}
+  - 114: {fileID: 114000012363744548}
+  m_Layer: 5
+  m_Name: Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -347,6 +467,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000013101734812
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000013264222304}
+  - 222: {fileID: 222000011746773390}
+  - 114: {fileID: 114000013430719180}
+  m_Layer: 5
+  m_Name: EndScreen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
 --- !u!1 &1000013118465618
 GameObject:
   m_ObjectHideFlags: 1
@@ -379,7 +516,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1000013287905726
 GameObject:
   m_ObjectHideFlags: 1
@@ -486,7 +623,7 @@ GameObject:
   - 114: {fileID: 114000011705464396}
   m_Layer: 5
   m_Name: HealthUI
-  m_TagString: Untagged
+  m_TagString: HealthUI
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -607,6 +744,39 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &114000010336469126
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011983675010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.26470572, g: 0.08088237, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 100
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 1
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Blue Team Wins!
 --- !u!114 &114000010365190902
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -634,6 +804,39 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+--- !u!114 &114000010434038904
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010728149296}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 60
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 6
+    m_MaxSize: 60
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Score: Red: Blue: '
 --- !u!114 &114000010497188738
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1009,6 +1212,7 @@ MonoBehaviour:
   speedButton: Speed Crew
   attackButton: Attack Crew
   defenseButton: Defense Crew
+  boat: {fileID: 0}
 --- !u!114 &114000011553621858
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1163,6 +1367,33 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.Slider+SliderEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
+--- !u!114 &114000011718831702
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012163253234}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
 --- !u!114 &114000011829100000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1223,6 +1454,107 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+--- !u!114 &114000012333502436
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010370936638}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 60
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 6
+    m_MaxSize: 60
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: You Win!
+--- !u!114 &114000012363744548
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012621375146}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Hurt Self
+
+'
+--- !u!114 &114000012688573902
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010460621602}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.08088237, b: 0.08088237, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 100
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 1
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Red Team Wins!
 --- !u!114 &114000012963465730
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1423,6 +1755,86 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.Slider+SliderEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &114000013430719180
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013101734812}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!114 &114000013519517360
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012163253234}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 114000011718831702}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114000011436452340, guid: 6d531ecf61d10f845b8c4b8c40a3fbe7,
+          type: 2}
+        m_MethodName: ChangeHealth
+        m_Mode: 4
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: -5
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
 --- !u!114 &114000013656240588
 MonoBehaviour:
@@ -1632,12 +2044,51 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+--- !u!114 &114000014272157998
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010537398346}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 60
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 6
+    m_MaxSize: 60
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: You Lose!
 --- !u!222 &222000010184185852
 CanvasRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000013392228026}
+--- !u!222 &222000010265003894
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010460621602}
 --- !u!222 &222000010265912832
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -1686,6 +2137,24 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000014147939808}
+--- !u!222 &222000011712506642
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010728149296}
+--- !u!222 &222000011746773390
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013101734812}
+--- !u!222 &222000011789448334
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012621375146}
 --- !u!222 &222000011800573488
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -1704,6 +2173,12 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000012932262736}
+--- !u!222 &222000012413296608
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012163253234}
 --- !u!222 &222000012528732454
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -1722,6 +2197,18 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000014001190854}
+--- !u!222 &222000013155161784
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011983675010}
+--- !u!222 &222000013163494462
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010537398346}
 --- !u!222 &222000013373225906
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -1734,6 +2221,12 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000011812019812}
+--- !u!222 &222000013790490338
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010370936638}
 --- !u!222 &222000013797788000
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -1892,6 +2385,24 @@ RectTransform:
   m_AnchoredPosition: {x: 14, y: -10}
   m_SizeDelta: {x: 40, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224000010825151130
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012621375146}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 224000013531459410}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000010836190448
 RectTransform:
   m_ObjectHideFlags: 1
@@ -2020,9 +2531,27 @@ RectTransform:
   m_Father: {fileID: 224000010940457322}
   m_RootOrder: 0
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224000011313589806
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010728149296}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 224000013264222304}
+  m_RootOrder: 4
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -35}
+  m_SizeDelta: {x: 400, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000011314774494
 RectTransform:
@@ -2038,7 +2567,7 @@ RectTransform:
   m_Father: {fileID: 224000012454622108}
   m_RootOrder: 0
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -2135,7 +2664,7 @@ RectTransform:
   m_Father: {fileID: 224000011947209938}
   m_RootOrder: 0
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -2157,6 +2686,42 @@ RectTransform:
   m_AnchorMax: {x: 1, y: 0.75}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224000012246945104
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010370936638}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 224000013264222304}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 75}
+  m_SizeDelta: {x: 400, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224000012321135810
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011983675010}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 224000013264222304}
+  m_RootOrder: 3
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 20}
+  m_SizeDelta: {x: 400, y: 70}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000012337241170
 RectTransform:
@@ -2310,6 +2875,24 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224000012818607692
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010460621602}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 224000013264222304}
+  m_RootOrder: 2
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 20}
+  m_SizeDelta: {x: 400, y: 70}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000013107818204
 RectTransform:
   m_ObjectHideFlags: 1
@@ -2332,6 +2915,29 @@ RectTransform:
   m_AnchoredPosition: {x: 0.00000071525574, y: 0}
   m_SizeDelta: {x: 100, y: 70}
   m_Pivot: {x: 0.5, y: 0}
+--- !u!224 &224000013264222304
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013101734812}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 224000012246945104}
+  - {fileID: 224000013326558556}
+  - {fileID: 224000012818607692}
+  - {fileID: 224000012321135810}
+  - {fileID: 224000011313589806}
+  m_Father: {fileID: 224000013668773754}
+  m_RootOrder: 3
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000013275605902
 RectTransform:
   m_ObjectHideFlags: 1
@@ -2352,6 +2958,24 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 20}
   m_Pivot: {x: 1, y: 0}
+--- !u!224 &224000013326558556
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010537398346}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 224000013264222304}
+  m_RootOrder: 1
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 75}
+  m_SizeDelta: {x: 400, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000013478158298
 RectTransform:
   m_ObjectHideFlags: 1
@@ -2370,6 +2994,25 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224000013531459410
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012163253234}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 224000010825151130}
+  m_Father: {fileID: 224000013668773754}
+  m_RootOrder: 2
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 1, y: 0}
 --- !u!224 &224000013558671528
 RectTransform:
   m_ObjectHideFlags: 1
@@ -2420,6 +3063,8 @@ RectTransform:
   m_Children:
   - {fileID: 224000012408917136}
   - {fileID: 224000011387924592}
+  - {fileID: 224000013531459410}
+  - {fileID: 224000013264222304}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_AnchorMin: {x: 0, y: 0}

--- a/Twisted Sails/Assets/Prefabs/Mileston2Boat.prefab
+++ b/Twisted Sails/Assets/Prefabs/Mileston2Boat.prefab
@@ -548,6 +548,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000011746906118
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000010890712004}
+  - 222: {fileID: 222000012901618490}
+  - 114: {fileID: 114000014251582768}
+  m_Layer: 5
+  m_Name: Nametag
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1000011748897618
 GameObject:
   m_ObjectHideFlags: 1
@@ -5540,6 +5557,8 @@ MonoBehaviour:
   activeCamera: {fileID: 0}
   explosion: {fileID: 1000011769946516, guid: 8af0c4ff01de10c4a9980db85d6bf910, type: 2}
   spawnPoint: {x: 0, y: 0, z: 0}
+  team: 0
+  playerName: 
 --- !u!114 &114000011472782010
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -5796,7 +5815,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000011748897618}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
@@ -5811,11 +5830,11 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
+    m_FontSize: 90
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
+    m_MinSize: 9
+    m_MaxSize: 90
     m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
@@ -5837,6 +5856,39 @@ MonoBehaviour:
   shipCamera: {fileID: 0}
   projectileSpeed: 10
   scaleFactor: 0.25
+--- !u!114 &114000014251582768
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011746906118}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 90
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: ???
 --- !u!136 &136000010038954510
 CapsuleCollider:
   m_ObjectHideFlags: 1
@@ -5966,6 +6018,12 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000011748897618}
+--- !u!222 &222000012901618490
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011746906118}
 --- !u!222 &222000013080311510
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -6003,11 +6061,29 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 224000013967751528}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224000010890712004
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011746906118}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 224000013967751528}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 17.499989}
+  m_SizeDelta: {x: 500, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000010892213954
 RectTransform:
@@ -6017,15 +6093,15 @@ RectTransform:
   m_GameObject: {fileID: 1000011748897618}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.15, y: 0.15, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 224000013967751528}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 100}
+  m_SizeDelta: {x: 650, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000011082283882
 RectTransform:
@@ -6040,7 +6116,7 @@ RectTransform:
   m_Children:
   - {fileID: 224000011696575194}
   m_Father: {fileID: 224000013967751528}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -6094,6 +6170,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
+  - {fileID: 224000010890712004}
   - {fileID: 224000010766824770}
   - {fileID: 224000011082283882}
   - {fileID: 224000010892213954}

--- a/Twisted Sails/Assets/Scenes/Milestone 2.unity
+++ b/Twisted Sails/Assets/Scenes/Milestone 2.unity
@@ -37,7 +37,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44692534, g: 0.49678725, b: 0.57508564, a: 1}
+  m_IndirectSpecularColor: {r: 0.44692492, g: 0.4967869, b: 0.57508546, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -186,129 +186,6 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 6d531ecf61d10f845b8c4b8c40a3fbe7, type: 2}
   m_IsPrefabParent: 0
---- !u!1 &110709604
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
-  m_Component:
-  - 224: {fileID: 110709605}
-  - 222: {fileID: 110709608}
-  - 114: {fileID: 110709607}
-  - 114: {fileID: 110709606}
-  m_Layer: 5
-  m_Name: Hurt Self
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &110709605
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 110709604}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_Children:
-  - {fileID: 1695502416}
-  m_Father: {fileID: 536947865}
-  m_RootOrder: 2
-  m_AnchorMin: {x: 1, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 30}
-  m_Pivot: {x: 1, y: 0}
---- !u!114 &110709606
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 110709604}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 110709607}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 114000011436452340, guid: 6d531ecf61d10f845b8c4b8c40a3fbe7,
-          type: 2}
-        m_MethodName: ChangeHealth
-        m_Mode: 4
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: -5
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
---- !u!114 &110709607
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 110709604}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
---- !u!222 &110709608
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 110709604}
 --- !u!1 &318691541
 GameObject:
   m_ObjectHideFlags: 0
@@ -399,11 +276,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 10
---- !u!224 &536947865 stripped
-RectTransform:
-  m_PrefabParentObject: {fileID: 224000013668773754, guid: d5a7615a31cde7d4c9dab5c7b4234ff6,
-    type: 2}
-  m_PrefabInternal: {fileID: 864195705}
 --- !u!1 &584372606
 GameObject:
   m_ObjectHideFlags: 0
@@ -429,10 +301,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 584372606}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 227461547, guid: 870353891bb340e2b2a9c8707e7419ba, type: 3}
+  m_Script: {fileID: 11500000, guid: 0a1280c807ef8f34dbd2dcd9ac9db459, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  manager: {fileID: 0}
   showGUI: 1
   offsetX: 0
   offsetY: 0
@@ -444,7 +315,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 584372606}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -822479833, guid: 870353891bb340e2b2a9c8707e7419ba, type: 3}
+  m_Script: {fileID: 11500000, guid: d5f020bf4a6e0bd4a9e7a8300d7e8abf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_NetworkPort: 7777
@@ -506,6 +377,9 @@ MonoBehaviour:
   matchSize: 4
   isNetworkActive: 0
   matchMaker: {fileID: 0}
+  currentGamemode: 0
+  localPlayerName: 
+  localPlayerTeam: 0
 --- !u!4 &584372609
 Transform:
   m_ObjectHideFlags: 0
@@ -620,38 +494,10 @@ Prefab:
       propertyPath: m_Pivot.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 224000011790169756, guid: d5a7615a31cde7d4c9dab5c7b4234ff6,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224000011125442554, guid: d5a7615a31cde7d4c9dab5c7b4234ff6,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224000011314774494, guid: d5a7615a31cde7d4c9dab5c7b4234ff6,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 224000011118632542, guid: d5a7615a31cde7d4c9dab5c7b4234ff6,
         type: 2}
       propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114000011509587546, guid: d5a7615a31cde7d4c9dab5c7b4234ff6,
-        type: 2}
-      propertyPath: boat
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1000013124347324, guid: d5a7615a31cde7d4c9dab5c7b4234ff6, type: 2}
-      propertyPath: m_IsActive
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1000013879850324, guid: d5a7615a31cde7d4c9dab5c7b4234ff6, type: 2}
-      propertyPath: m_TagString
-      value: HealthUI
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: d5a7615a31cde7d4c9dab5c7b4234ff6, type: 2}
@@ -744,6 +590,7 @@ MonoBehaviour:
   camTransform: {fileID: 0}
   sensitivityX: 4
   sensitivityY: 1
+  scrollSensitivity: 10
   offsetX: 1
   offsetY: 1
 --- !u!81 &1219771392
@@ -1141,82 +988,6 @@ MonoBehaviour:
   m_Script: {fileID: -1050975500, guid: 870353891bb340e2b2a9c8707e7419ba, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1695502415
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
-  m_Component:
-  - 224: {fileID: 1695502416}
-  - 222: {fileID: 1695502418}
-  - 114: {fileID: 1695502417}
-  m_Layer: 5
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1695502416
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1695502415}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_Children: []
-  m_Father: {fileID: 110709605}
-  m_RootOrder: 0
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1695502417
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1695502415}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 'Hurt Self
-
-'
---- !u!222 &1695502418
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1695502415}
 --- !u!1 &1809362391
 GameObject:
   m_ObjectHideFlags: 0

--- a/Twisted Sails/Assets/Scripts/Billboard.cs
+++ b/Twisted Sails/Assets/Scripts/Billboard.cs
@@ -3,10 +3,15 @@ using System.Collections;
 
 //The only purpose of this script is to have a component always facing the camera
 //Currently only used to have health bars above other ships be always visible
+
+//Developer: Kyle Aycock
+//Date: 11/3/2016
+//Fixed so that text is oriented towards the camera properly.
+//Previously any billboarded text appeared mirrored.
 public class Billboard : MonoBehaviour
 {
     void Update()
     {
-        transform.LookAt(Camera.main.transform);
+        transform.rotation = Quaternion.LookRotation(Camera.main.transform.forward,Vector3.up);
     }
 }

--- a/Twisted Sails/Assets/Scripts/Health.cs
+++ b/Twisted Sails/Assets/Scripts/Health.cs
@@ -61,7 +61,6 @@ public class Health : NetworkBehaviour
 
     private float respawnTimer;
     private bool tilting;
-    private NetworkInstanceId lastHitBy;
     private bool gameOver;
 
     void Start()
@@ -99,7 +98,6 @@ public class Health : NetworkBehaviour
         }
         healthSlider.minValue = 0f;
         healthSlider.maxValue = 100f;
-        lastHitBy = NetworkInstanceId.Invalid;
         OnChangeHealth(health);
     }
 
@@ -141,14 +139,18 @@ public class Health : NetworkBehaviour
     void OnCollisionEnter(Collision c)
     {
         //Ignore cannonball collisions with owner
-        if (c.transform.gameObject.tag.Equals("Cannonball") && c.gameObject.GetComponent<CannonBallNetworked>().owner != GetComponent<NetworkIdentity>().netId) //todo: change this to use tags when possible
+        if (c.transform.gameObject.tag.Equals("Cannonball") && c.gameObject.GetComponent<CannonBallNetworked>().owner != GetComponent<NetworkIdentity>().netId)
         {
-            if (isLocalPlayer)
+            Team cannonballTeam = ClientScene.FindLocalObject(c.gameObject.GetComponent<CannonBallNetworked>().owner).GetComponent<Health>().team;
+            if (cannonballTeam != team)
             {
-                CmdChangeHealth(-35, c.transform.gameObject.GetComponent<CannonBallNetworked>().owner);
+                if (isLocalPlayer)
+                {
+                    CmdChangeHealth(-35, c.transform.gameObject.GetComponent<CannonBallNetworked>().owner);
+                }
+                GameObject explode = (GameObject)Instantiate(explosion, c.contacts[0].point, Quaternion.identity);
+                explode.GetComponent<ParticleSystem>().Emit(100);
             }
-            GameObject explode = (GameObject)Instantiate(explosion, c.contacts[0].point, Quaternion.identity);
-            explode.GetComponent<ParticleSystem>().Emit(100);
             Destroy(c.gameObject);
         }
 

--- a/Twisted Sails/Assets/Scripts/Health.cs
+++ b/Twisted Sails/Assets/Scripts/Health.cs
@@ -9,14 +9,14 @@ using UnityEngine.Networking;
 // Developer:       Kyle Aycock
 // Date:            10/7/2016
 // Description:     NOTE: I kind of reworked this script to serve as more of a general ship controller - it controls health, respawning, & collisions
-//                  ADDED ChangeHealth function to avoid clogging the update loop with needless health checks
-//                  ADDED several public variables for interfacing with health UI, camera
-//                  CHANGED existing code to use ChangeHealth function, Health UI
-//                  ADDED code for death animation, switching camera modes to orbital on death
-//                  FIXED cannonball collision code - however, cannonballs need to be nocollided with the ship collider!
-//                  ADDED cannonball explosions!
-//                  CHANGED public variables organized into groups because there's too many
-//                  CHANGED OnTriggerEnter to OnCollisionEnter because the cannonballs are not triggers
+//                  Added ChangeHealth function to avoid clogging the update loop with needless health checks
+//                  Added several public variables for interfacing with health UI, camera
+//                  Changed existing code to use ChangeHealth function, Health UI
+//                  Added code for death animation, switching camera modes to orbital on death
+//                  Fixed cannonball collision code - however, cannonballs need to be nocollided with the ship collider!
+//                  Added cannonball explosions!
+//                  Changed public variables organized into groups because there's too many
+//                  Changed OnTriggerEnter to OnCollisionEnter because the cannonballs are not triggers
 
 //Developed:		Kyle Chapman
 //Date:				10/20/2016
@@ -27,26 +27,42 @@ using UnityEngine.Networking;
 // Description:     Fixed cannonball collisions for networking
 //                  Cleaned up code a bit
 //                  Added code to support health bars above other ships
+
+//Developer:        Kyle Aycock
+//Date:             11/3/2016
+//Description:      Haphazardly threw in much network-related functionality. Requires cleanup
+//                  Moved Death and Respawn procedures to separate methods
+//                  Added nametag support
+//                  Updated CmdChangeHealth to communicate with server manager on death
+//                  Added CmdPlayerInit, the purpose of which is to tell the server the player was successfully spawned
+//                  Added RpcEndGame and RpcRestartGame which communicate with new elements of the main Canvas object
 public class Health : NetworkBehaviour
 {
     [Header("Health")]
     //Decided to just have it hook to the ChangeHealth function
-    [SyncVar(hook = "OnChangeHealth")] public float health;
+    [SyncVar(hook = "OnChangeHealth")]
+    public float health;
     public Text healthText;
     public Slider healthSlider;
     [Header("Sinking")]
     public float sinkSpeed;
     public float sinkAngle;
     public float secondsToRespawn;
-	[Header("Misc")]
-	public KeyCode hurtSelfButton;
+    [Header("Misc")]
+    public KeyCode hurtSelfButton;
     public bool dead;
     public GameObject activeCamera;
     public GameObject explosion;
     public Vector3 spawnPoint; // NK 10/20 added original spawnpoint
-    
+    [SyncVar]
+    public Team team;
+    [SyncVar]
+    public string playerName;
+
     private float respawnTimer;
     private bool tilting;
+    private NetworkInstanceId lastHitBy;
+    private bool gameOver;
 
     void Start()
     {
@@ -55,6 +71,7 @@ public class Health : NetworkBehaviour
         dead = false;
         tilting = false;
         spawnPoint = this.transform.position;
+        gameOver = false;
 
         if (isLocalPlayer)
         {
@@ -62,17 +79,27 @@ public class Health : NetworkBehaviour
             GameObject UI = GameObject.FindGameObjectWithTag("HealthUI");
             healthSlider = UI.GetComponent<Slider>(); // NK 10/20: locates the health UI in the scene
             healthText = UI.GetComponentInChildren<Text>(); // NK 10/20 locates the health text in the scene
+            Player player = new Player(playerName, team, GetComponent<NetworkIdentity>().netId, MultiplayerManager.instance.client.connection.connectionId);
+            MultiplayerManager.localPlayer = player;
+            CmdPlayerInit(playerName, team, player.connectionId);
         }
         else
         {
             //Otherwise, use the healthbar that's currently disabled within the ship
             GameObject UI = transform.FindChild("Canvas").FindChild("HealthUI").gameObject;
             healthSlider = UI.GetComponent<Slider>();
-            healthText = UI.GetComponentInChildren<Text>();
+            if (isClient)
+            {
+                if (ClientScene.localPlayers[0].gameObject.GetComponent<Health>().team == team)
+                    healthSlider.transform.FindChild("Fill Area").GetChild(0).GetComponent<Image>().color = Color.green;
+            }
+            healthText = UI.transform.FindChild("Text").GetComponent<Text>();
+            UI.transform.FindChild("Nametag").GetComponent<Text>().text = playerName;
             UI.SetActive(true);
         }
         healthSlider.minValue = 0f;
         healthSlider.maxValue = 100f;
+        lastHitBy = NetworkInstanceId.Invalid;
         OnChangeHealth(health);
     }
 
@@ -93,37 +120,21 @@ public class Health : NetworkBehaviour
                 }
             }
             //Respawn
+            if (gameOver) return;
             respawnTimer += Time.deltaTime;
             if (respawnTimer > secondsToRespawn)
             {
-                //The following code effectively "re-initializes" the boat to its original state
-                //Re-enable normal boat scripts, disable death-related scripts, re-initialize positions, rotations, forces
-                if (isLocalPlayer)
-                {
-                    //Only manipulate the camera if it's our ship that's respawning
-                    activeCamera.GetComponent<BoatCameraNetworked>().enabled = true; //must change this to match whatever the active camera controller is
-                    activeCamera.GetComponent<OrbitalCamera>().enabled = false;
-                    CmdChangeHealth(100);
-                }
-                GetComponent<BoatMovementNetworked>().enabled = true;
-                GetComponent<Buoyancy>().enabled = true;
-                GetComponent<Rigidbody>().useGravity = true;
-                GetComponent<Rigidbody>().constraints = RigidbodyConstraints.FreezeRotationX | RigidbodyConstraints.FreezeRotationZ;
-                GetComponent<Rigidbody>().velocity = Vector3.zero;
-                GetComponent<Rigidbody>().angularVelocity = Vector3.zero;
-                transform.position = spawnPoint;
-                transform.rotation = Quaternion.identity;
-                dead = false;
+                Respawn();
             }
         }
 
-		if (isLocalPlayer && Input.GetKeyDown(hurtSelfButton))
-		{
-            CmdChangeHealth(-5);
-			return;
-		}
+        if (isLocalPlayer && Input.GetKeyDown(hurtSelfButton))
+        {
+            CmdChangeHealth(-5, NetworkInstanceId.Invalid);
+            return;
+        }
 
-	}
+    }
 
 
     //Whenever ship collides with something else
@@ -134,8 +145,7 @@ public class Health : NetworkBehaviour
         {
             if (isLocalPlayer)
             {
-                Debug.Log("Health changed!");
-                CmdChangeHealth(-35);
+                CmdChangeHealth(-35, c.transform.gameObject.GetComponent<CannonBallNetworked>().owner);
             }
             GameObject explode = (GameObject)Instantiate(explosion, c.contacts[0].point, Quaternion.identity);
             explode.GetComponent<ParticleSystem>().Emit(100);
@@ -154,12 +164,22 @@ public class Health : NetworkBehaviour
 		}*/
     }
 
+    [Command]
+    public void CmdPlayerInit(string name, Team team, int connectionId)
+    {
+        Player newPlayer = new Player(name, team, GetComponent<NetworkIdentity>().netId, connectionId);
+        MultiplayerManager.instance.playerList.Add(newPlayer);
+    }
+
     //Apparently, SyncVars with hooks only call one way (Server -> Client)
     //So I had to make a command so that health changes only happen on the server
     [Command]
-    public void CmdChangeHealth(float amt)
+    public void CmdChangeHealth(float amt, NetworkInstanceId src)
     {
-        health = Mathf.Clamp(health+amt,0,100);
+        if (health == 0 && amt < 0) return; //don't register damage taken after death
+        health = Mathf.Clamp(health + amt, 0, 100);
+        if (health == 0)
+            MultiplayerManager.instance.PlayerKill(GetComponent<NetworkIdentity>().netId, src);
     }
 
 
@@ -175,21 +195,82 @@ public class Health : NetworkBehaviour
         }
         if (health <= 0 && !dead)
         {
-            dead = true;
-            tilting = true;
-            respawnTimer = 0;
-
-            //The code below puts the ship into an automated death sequence
-            if (isLocalPlayer)
-            {
-                //Only manipulate the camera if it's the player's ship that's dying
-                activeCamera.GetComponent<BoatCameraNetworked>().enabled = false; //change BoatCamera to match whatever the active camera controller script is
-                activeCamera.GetComponent<OrbitalCamera>().enabled = true;
-            }
-            GetComponent<BoatMovementNetworked>().enabled = false;
-            GetComponent<Buoyancy>().enabled = false;
-            GetComponent<Rigidbody>().useGravity = false;
-            GetComponent<Rigidbody>().constraints = RigidbodyConstraints.None;
+            Death();
         }
+    }
+
+    public void Death()
+    {
+        dead = true;
+        tilting = true;
+        respawnTimer = 0;
+
+        //The code below puts the ship into an automated death sequence
+        if (isLocalPlayer)
+        {
+            //Only manipulate the camera if it's the player's ship that's dying
+            activeCamera.GetComponent<BoatCameraNetworked>().enabled = false; //change BoatCamera to match whatever the active camera controller script is
+            activeCamera.GetComponent<OrbitalCamera>().enabled = true;
+        }
+        GetComponent<BoatMovementNetworked>().enabled = false;
+        GetComponent<Buoyancy>().enabled = false;
+        GetComponent<Rigidbody>().useGravity = false;
+        GetComponent<Rigidbody>().constraints = RigidbodyConstraints.None;
+
+    }
+
+    public void Respawn()
+    {
+        //The following code effectively "re-initializes" the boat to its original state
+        //Re-enable normal boat scripts, disable death-related scripts, re-initialize positions, rotations, forces
+        if (isLocalPlayer)
+        {
+            //Only manipulate the camera if it's our ship that's respawning
+            activeCamera.GetComponent<BoatCameraNetworked>().enabled = true; //must change this to match whatever the active camera controller is
+            activeCamera.GetComponent<OrbitalCamera>().enabled = false;
+            CmdChangeHealth(100, NetworkInstanceId.Invalid);
+        }
+        GetComponent<BoatMovementNetworked>().enabled = true;
+        GetComponent<Buoyancy>().enabled = true;
+        GetComponent<Rigidbody>().useGravity = true;
+        GetComponent<Rigidbody>().constraints = RigidbodyConstraints.FreezeRotationX | RigidbodyConstraints.FreezeRotationZ;
+        GetComponent<Rigidbody>().velocity = Vector3.zero;
+        GetComponent<Rigidbody>().angularVelocity = Vector3.zero;
+        transform.position = spawnPoint;
+        transform.rotation = Quaternion.identity;
+        dead = false;
+    }
+
+    [ClientRpc]
+    public void RpcEndGame(Team winner, int redScore, int blueScore)
+    {
+        if (!isLocalPlayer) return;
+        activeCamera.GetComponent<BoatCameraNetworked>().enabled = false; //change BoatCamera to match whatever the active camera controller script is
+        activeCamera.GetComponent<OrbitalCamera>().enabled = true;
+        gameOver = true;
+        GameObject endScreen = GameObject.Find("Canvas(Health)").transform.FindChild("EndScreen").gameObject;
+        endScreen.SetActive(true);
+        if (winner == Team.Blue)
+            endScreen.transform.FindChild("BlueTeamWins").gameObject.SetActive(true);
+        else
+            endScreen.transform.FindChild("RedTeamWins").gameObject.SetActive(true);
+        if (winner == team)
+            endScreen.transform.FindChild("YouWin").gameObject.SetActive(true);
+        else
+            endScreen.transform.FindChild("YouLose").gameObject.SetActive(true);
+        endScreen.transform.FindChild("FinalScore").GetComponent<Text>().text = "Score: Red: " + redScore + " Blue: " + blueScore;
+    }
+
+    [ClientRpc]
+    public void RpcRestartGame()
+    {
+        gameOver = false;
+        Respawn();
+        GameObject endScreen = GameObject.Find("Canvas(Health)").transform.FindChild("EndScreen").gameObject;
+        endScreen.SetActive(false);
+        endScreen.transform.FindChild("BlueTeamWins").gameObject.SetActive(false);
+        endScreen.transform.FindChild("RedTeamWins").gameObject.SetActive(false);
+        endScreen.transform.FindChild("YouWin").gameObject.SetActive(false);
+        endScreen.transform.FindChild("YouLose").gameObject.SetActive(false);
     }
 }

--- a/Twisted Sails/Assets/Scripts/MultiplayerManager.cs
+++ b/Twisted Sails/Assets/Scripts/MultiplayerManager.cs
@@ -1,0 +1,236 @@
+﻿using UnityEngine;
+using System.Collections;
+using UnityEngine.Networking;
+using System.Collections.Generic;
+using System;
+
+// Developer: Kyle Aycock
+// Date: 11/3/2016
+// This is a class inheriting from the default Unity NetworkManager that should be used
+// to make changes to the way NetworkManager operates. It is extremely helpful to reference
+// the code for Unity's NetworkManager which can be found open source at this link:
+// https://bitbucket.org/Unity-Technologies/networking/
+//
+// This class is currently serving as a general multiplayer game controller. The functionality
+// of the default NetworkManager has been extended to make it easier to work with.
+// Also included are two enums and a container class that I didn't feel deserved their own file.
+
+//Enum for all teams
+public enum Team
+{
+    Red,
+    Blue,
+    Spectator
+}
+
+//Unnecessary right now but can be extended to include other gamemodes and time/stock options
+public enum Gamemode
+{
+    TeamDeathmatch
+}
+
+//container class for all info for a single player
+public class Player
+{
+    public string name;
+    public Team team;
+    public NetworkInstanceId shipId;
+    public int connectionId;
+    public int kills;
+    public int deaths;
+    public int bounty;
+    public int score;
+
+    public Player(string name, Team team, NetworkInstanceId shipId, int connectionId)
+    {
+        this.name = name;
+        this.team = team;
+        this.shipId = shipId;
+        this.connectionId = connectionId;
+        kills = 0;
+        deaths = 0;
+        bounty = 0;
+        score = 0;
+    }
+}
+
+public class MultiplayerManager : NetworkManager
+{
+
+    public Gamemode currentGamemode = Gamemode.TeamDeathmatch;
+    public string localPlayerName;
+    public Team localPlayerTeam;
+    public List<Player> playerList;
+    public Dictionary<Team, int> teamScores;
+    public static Player localPlayer;
+    public static MultiplayerManager instance;
+
+    private float gameRestartTimer;
+
+    //Initialization of variables
+    public void Start()
+    {
+        localPlayerName = "???";
+        localPlayerTeam = Team.Spectator;
+        playerList = new List<Player>();
+        instance = this;
+        teamScores = new Dictionary<Team, int>();
+        foreach (Team team in Enum.GetValues(typeof(Team)))
+        {
+            teamScores[team] = 0;
+        }
+    }
+
+    //Only used for restarting the game
+    public void Update()
+    {
+        if (gameRestartTimer > 0)
+        {
+            gameRestartTimer -= Time.deltaTime;
+            if (gameRestartTimer <= 0)
+            {
+                foreach (Team team in Enum.GetValues(typeof(Team)))
+                {
+                    teamScores[team] = 0;
+                }
+                foreach (Player player in playerList)
+                    NetworkServer.FindLocalObject(player.shipId).GetComponent<Health>().RpcRestartGame();
+            }
+        }
+    }
+
+    //Processes a player death, this method is called from the Health script
+    public void PlayerKill(NetworkInstanceId killed, NetworkInstanceId by)
+    {
+        Player victim = playerList.Find(p => p.shipId == killed);
+        Player killer = playerList.Find(p => p.shipId == by);
+        victim.deaths++;
+        if (killer != null && killer.team != victim.team)
+        {
+            killer.kills++;
+            teamScores[killer.team] += 1;
+            Debug.Log("Player " + killer.name + " killed player " + victim.name + "!");
+        }
+        else Debug.Log("Player " + victim.name + " suicided!");
+        CheckEndGame();
+    }
+
+    //The functionality of this method can be expanded when multiple gamemodes are added
+    public void CheckEndGame()
+    {
+        foreach (Team team in Enum.GetValues(typeof(Team)))
+            if (teamScores[team] >= 10)
+            {
+                gameRestartTimer = 10;
+                foreach (Player player in playerList)
+                    NetworkServer.FindLocalObject(player.shipId).GetComponent<Health>().RpcEndGame(team, teamScores[Team.Red], teamScores[Team.Blue]);
+            }
+    }
+
+    //This hook method is automatically called when the server is instructed to spawn a player
+    public override void OnServerAddPlayer(NetworkConnection conn, short playerControllerId)
+    {
+        ServerAddPlayer(conn, playerControllerId, "???", Team.Spectator);
+    }
+
+    //This hook method is automatically called when the server is instructed to spawn a player (and provided extra info)
+    public override void OnServerAddPlayer(NetworkConnection conn, short playerControllerId, NetworkReader extraMessageReader)
+    {
+        SpawnMessage msg = new SpawnMessage("", Team.Spectator);
+        msg.Deserialize(extraMessageReader);
+        ServerAddPlayer(conn, playerControllerId, msg.name, (Team)msg.team);
+
+    }
+
+    //most of the code for this taken from the internal ServerAddPlayer method used by the default NetworkManager
+    //This method performs the actual spawning of a player
+    void ServerAddPlayer(NetworkConnection conn, short playerControllerId, string playerName, Team playerTeam)
+    {
+        if (playerPrefab == null)
+        {
+            if (LogFilter.logError) { Debug.LogError("The PlayerPrefab is empty on the NetworkManager. Please setup a PlayerPrefab object."); }
+            return;
+        }
+
+        if (playerPrefab.GetComponent<NetworkIdentity>() == null)
+        {
+            if (LogFilter.logError) { Debug.LogError("The PlayerPrefab does not have a NetworkIdentity. Please add a NetworkIdentity to the player prefab."); }
+            return;
+        }
+
+        if (playerControllerId < conn.playerControllers.Count && conn.playerControllers[playerControllerId].IsValid && conn.playerControllers[playerControllerId].gameObject != null)
+        {
+            if (LogFilter.logError) { Debug.LogError("There is already a player at that playerControllerId for this connections."); }
+            return;
+        }
+
+        GameObject player;
+        Transform startPos = GetStartPosition();
+        if (startPos != null)
+        {
+            player = (GameObject)Instantiate(playerPrefab, startPos.position, startPos.rotation);
+        }
+        else
+        {
+            player = (GameObject)Instantiate(playerPrefab, Vector3.zero, Quaternion.identity);
+        }
+        if(playerTeam == Team.Spectator)
+        {
+            int redCount = playerList.FindAll(p => p.team == Team.Red).Count;
+            int blueCount = playerList.FindAll(p => p.team == Team.Blue).Count;
+            if (redCount > blueCount)
+                playerTeam = Team.Blue;
+            else
+                playerTeam = Team.Red;
+        }
+        player.GetComponent<Health>().team = playerTeam;
+        player.GetComponent<Health>().playerName = playerName;
+
+        NetworkServer.AddPlayerForConnection(conn, player, playerControllerId);
+    }
+
+    //Only purpose of overriding this is to make it do nothing
+    //The base method readies the scene & spawns the player immediately upon connection
+    public override void OnClientConnect(NetworkConnection conn)
+    {
+    }
+
+    //Only purpose of overriding is to properly manage the playerList
+    public override void OnServerRemovePlayer(NetworkConnection conn, PlayerController player)
+    {
+        playerList.Remove(playerList.Find(x => x.connectionId == conn.connectionId));
+        base.OnServerRemovePlayer(conn, player);
+    }
+
+    //Called by NetworkHUD - tells the network client to tell the server to spawn a player
+    //The result of this method is that OnServerAddPlayer is called
+    public void SpawnClient()
+    {
+        ClientScene.AddPlayer(client.connection, 0, new SpawnMessage(localPlayerName, localPlayerTeam));
+    }
+
+    //This is a custom message to send name and team choices to the server
+    class SpawnMessage : MessageBase
+    {
+        public string name;
+        public short team;
+
+        public SpawnMessage(string name, Team team)
+        {
+            this.name = name;
+            this.team = (short)team;
+        }
+
+        public override void Serialize(NetworkWriter writer)
+        {
+            writer.Write(name);
+            writer.Write(team);
+        }
+
+        public override void Deserialize(NetworkReader reader)
+        {
+            name = reader.ReadString();
+            team = reader.ReadInt16();
+        }
+    }
+}

--- a/Twisted Sails/Assets/Scripts/MultiplayerManager.cs.meta
+++ b/Twisted Sails/Assets/Scripts/MultiplayerManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d5f020bf4a6e0bd4a9e7a8300d7e8abf
+timeCreated: 1478146651
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Twisted Sails/Assets/Scripts/NetworkHUD.cs
+++ b/Twisted Sails/Assets/Scripts/NetworkHUD.cs
@@ -1,0 +1,132 @@
+﻿#if ENABLE_UNET
+
+using UnityEngine;
+using UnityEngine.Networking;
+
+// Developer: Kyle Aycock
+// Date: 11/3/2016
+// This is a heavily modified version of the original 'NetworkManagerHUD'. The code for
+// NetworkManagerHUD is open source at: https://bitbucket.org/Unity-Technologies/networking/
+//
+// Added new GUI controls to input name and preferred team
+
+[RequireComponent(typeof(NetworkManager))]
+public class NetworkHUD : MonoBehaviour
+{
+    private MultiplayerManager manager;
+    [SerializeField]
+    public bool showGUI = true;
+    [SerializeField]
+    public int offsetX;
+    [SerializeField]
+    public int offsetY;
+
+    int teamSelection;
+
+    void Awake()
+    {
+        manager = GetComponent<MultiplayerManager>();
+        teamSelection = Random.Range(0, 2);
+    }
+
+    void Update()
+    {
+        if (!showGUI)
+            return;
+        if (NetworkServer.active || manager.IsClientConnected())
+        {
+            if (Input.GetKeyDown(KeyCode.X))
+            {
+                manager.StopHost();
+            }
+        }
+    }
+
+    void OnGUI()
+    {
+        if (!showGUI)
+            return;
+
+        int xpos = 10 + offsetX;
+        int ypos = 40 + offsetY;
+        int spacing = 24;
+
+        if (!NetworkClient.active && !NetworkServer.active && manager.matchMaker == null)
+        {
+            if (GUI.Button(new Rect(xpos, ypos, 200, 20), "LAN Host"))
+            {
+                manager.StartHost();
+            }
+            ypos += spacing;
+
+            if (GUI.Button(new Rect(xpos, ypos, 95, 20), "LAN Client"))
+            {
+                manager.StartClient();
+            }
+            manager.networkAddress = GUI.TextField(new Rect(xpos + 105, ypos, 95, 20), manager.networkAddress);
+            ypos += spacing;
+
+            if (GUI.Button(new Rect(xpos, ypos, 200, 20), "LAN Server Only"))
+            {
+                manager.StartServer();
+            }
+            ypos += spacing;
+        }
+        else
+        {
+            if (NetworkServer.active)
+            {
+                GUI.Label(new Rect(xpos, ypos, 300, 20), "Server: port=" + manager.networkPort);
+                ypos += spacing;
+            }
+            if (NetworkClient.active)
+            {
+                GUI.Label(new Rect(xpos, ypos, 300, 20), "Client: address=" + manager.networkAddress + " port=" + manager.networkPort);
+                ypos += spacing;
+            }
+        }
+
+        //New stuff starts here
+        if (NetworkClient.active && !ClientScene.ready)
+        {
+            GUI.Label(new Rect(xpos, ypos, 50, 20), "Name: ");
+            manager.localPlayerName = GUI.TextField(new Rect(xpos + 60, ypos, 140, 20), manager.localPlayerName);
+            ypos += spacing;
+
+            GUI.Label(new Rect(xpos, ypos, 50, 20), "Team: ");
+            teamSelection = GUI.SelectionGrid(new Rect(xpos + 60, ypos, 140, 20), teamSelection, new string[] { "Red", "Blue" }, 2);
+            manager.localPlayerTeam = (Team)teamSelection;
+            ypos += spacing;
+            if (GUI.Button(new Rect(xpos, ypos, 200, 20), "Join"))
+            {
+                ClientScene.Ready(manager.client.connection);
+
+                if (ClientScene.localPlayers.Count == 0)
+                {
+                    //Instructs the manager to spawn the client with the given name and team
+                    manager.SpawnClient();
+                }
+            }
+            ypos += spacing;
+        }
+        
+
+        if (NetworkServer.active || manager.IsClientConnected())
+        {
+            if(ClientScene.ready)
+            {
+                GUI.Label(new Rect(xpos, ypos, 300, 20), "Name: " + manager.localPlayerName);
+                ypos += spacing;
+                GUI.Label(new Rect(xpos, ypos, 300, 20), "Team: " + manager.localPlayerTeam.ToString());
+                ypos += spacing;
+            }
+            if (GUI.Button(new Rect(xpos, ypos, 200, 20), "Stop (X)"))
+            {
+                manager.StopHost();
+            }
+            ypos += spacing;
+        }
+        //New stuff ends here
+    }
+}
+#endif //ENABLE_UNET

--- a/Twisted Sails/Assets/Scripts/NetworkHUD.cs.meta
+++ b/Twisted Sails/Assets/Scripts/NetworkHUD.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0a1280c807ef8f34dbd2dcd9ac9db459
+timeCreated: 1478145399
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Sorry about this being so late!

Explanation of changed files:

Canvas(Health).prefab -- Added the "End Screen" to this canvas. The end screen and elements of it are enabled/disabled/changed when the appropriate method within the Health script is called.

Mileston2Boat.prefab -- Added nametags to the ship healthbars. These are also controlled by the Health script.

Milestone 2.unity -- Changes to the NetworkManager. Replaced both components with derived scripts. All multiplayer functionality is preserved.

Billboard.cs -- Fixed a bug where any text displayed on a canvas using this script was mirrored.

Health.cs -- Multiple changes to allow for nametags, game end/restart, and communicating player kills with server. See comments in the script for details. Of special note: Opponent healthbars are red, ally healthbars are green. Friendly fire is disabled, as requested.

MultiplayerManager.cs -- Script derived from NetworkManager. This was a necessary thing to do as components of a team-based game were impossible to perform with the default NetworkManager, such as team-based spawn points and allowing players to specify their name and preferred team before spawning.

NetworkHUD.cs -- Script based upon NetworkManagerHUD. Not exactly necessary, but it was a convenient place to add the ability to choose name and team before spawning in. Also, all functionality relating to Unity's weird "Matchmaker" system was removed and the GUI was cleaned up a bit. It also is where your current name and team are shown while in-game.