### PR TITLE
Scoreboard & Score gain display on kill

### DIFF
--- a/Twisted Sails/Assets/Scenes/Milestone 2.unity
+++ b/Twisted Sails/Assets/Scenes/Milestone 2.unity
@@ -307,6 +307,7 @@ MonoBehaviour:
   showGUI: 1
   offsetX: 0
   offsetY: 0
+  messageDisplayDuration: 2.5
 --- !u!114 &584372608
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -380,6 +381,7 @@ MonoBehaviour:
   currentGamemode: 0
   localPlayerName: 
   localPlayerTeam: 0
+  pointsToWin: 10
 --- !u!4 &584372609
 Transform:
   m_ObjectHideFlags: 0
@@ -497,7 +499,7 @@ Prefab:
     - target: {fileID: 224000011118632542, guid: d5a7615a31cde7d4c9dab5c7b4234ff6,
         type: 2}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: d5a7615a31cde7d4c9dab5c7b4234ff6, type: 2}
@@ -585,14 +587,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   boatToFollow: {fileID: 0}
-  Y_angle_Min: 10
-  Y_angle_Max: 50
-  camTransform: {fileID: 0}
+  minimumVerticalRotation: 10
+  maximumVerticalRotation: 50
+  minimumZoomDistance: 5
+  maximumZoomDistance: 25
   sensitivityX: 4
   sensitivityY: 1
   scrollSensitivity: 10
-  offsetX: 1
-  offsetY: 1
+  invertX: 0
+  invertY: 0
+  quickTurnAxis: 
+  quickTurnSpeed: 1
 --- !u!81 &1219771392
 AudioListener:
   m_ObjectHideFlags: 0

--- a/Twisted Sails/Assets/Scripts/Health.cs
+++ b/Twisted Sails/Assets/Scripts/Health.cs
@@ -79,7 +79,6 @@ public class Health : NetworkBehaviour
             healthSlider = UI.GetComponent<Slider>(); // NK 10/20: locates the health UI in the scene
             healthText = UI.GetComponentInChildren<Text>(); // NK 10/20 locates the health text in the scene
             Player player = new Player(playerName, team, GetComponent<NetworkIdentity>().netId, MultiplayerManager.instance.client.connection.connectionId);
-            MultiplayerManager.localPlayer = player;
             CmdPlayerInit(playerName, team, player.connectionId);
         }
         else
@@ -170,7 +169,7 @@ public class Health : NetworkBehaviour
     public void CmdPlayerInit(string name, Team team, int connectionId)
     {
         Player newPlayer = new Player(name, team, GetComponent<NetworkIdentity>().netId, connectionId);
-        MultiplayerManager.instance.playerList.Add(newPlayer);
+        MultiplayerManager.instance.RegisterPlayer(newPlayer);
     }
 
     //Apparently, SyncVars with hooks only call one way (Server -> Client)

--- a/Twisted Sails/Assets/Scripts/MultiplayerManager.cs
+++ b/Twisted Sails/Assets/Scripts/MultiplayerManager.cs
@@ -14,6 +14,10 @@ using System;
 // This class is currently serving as a general multiplayer game controller. The functionality
 // of the default NetworkManager has been extended to make it easier to work with.
 // Also included are two enums and a container class that I didn't feel deserved their own file.
+// Added code for broadcasting current game state (score, player stats, etc) to all players whenever
+// a change is made. This may be inefficient, but it's okay for now. At the very least it's needed
+// for when a new player joins, to synchronize the current game state with that player and tell everyone
+// else that a new player has joined. Also added stuff to help with the scoreboard and score feed.
 
 //Enum for all teams
 public enum Team
@@ -41,6 +45,8 @@ public class Player
     public int bounty;
     public int score;
 
+    public Player() { }
+
     public Player(string name, Team team, NetworkInstanceId shipId, int connectionId)
     {
         this.name = name;
@@ -52,6 +58,30 @@ public class Player
         bounty = 0;
         score = 0;
     }
+
+    public void Serialize(NetworkWriter writer)
+    {
+        writer.Write(name);
+        writer.Write((short)team);
+        writer.Write(shipId);
+        writer.Write(connectionId);
+        writer.Write(kills);
+        writer.Write(deaths);
+        writer.Write(bounty);
+        writer.Write(score);
+    }
+
+    public void Deserialize(NetworkReader reader)
+    {
+        name = reader.ReadString();
+        team = (Team)reader.ReadInt16();
+        shipId = reader.ReadNetworkId();
+        connectionId = reader.ReadInt32();
+        kills = reader.ReadInt32();
+        deaths = reader.ReadInt32();
+        bounty = reader.ReadInt32();
+        score = reader.ReadInt32();
+    }
 }
 
 public class MultiplayerManager : NetworkManager
@@ -62,7 +92,6 @@ public class MultiplayerManager : NetworkManager
     public Team localPlayerTeam;
     public List<Player> playerList;
     public Dictionary<Team, int> teamScores;
-    public static Player localPlayer;
     public static MultiplayerManager instance;
 
     private float gameRestartTimer;
@@ -108,10 +137,19 @@ public class MultiplayerManager : NetworkManager
         if (killer != null && killer.team != victim.team)
         {
             killer.kills++;
+            int scoreGain = 1 + victim.bounty;
             teamScores[killer.team] += 1;
+            killer.score += scoreGain;
+            KillMessage msg = new KillMessage();
+            msg.bountyGained = victim.bounty;
+            NetworkServer.SendToClient(killer.connectionId, ExtMsgType.Kill, msg);
+            victim.bounty = 0;
+            killer.bounty++;
             Debug.Log("Player " + killer.name + " killed player " + victim.name + "!");
         }
         else Debug.Log("Player " + victim.name + " suicided!");
+        
+        NetworkServer.SendToAll(ExtMsgType.State, new GameStateMessage(playerList, teamScores));
         CheckEndGame();
     }
 
@@ -189,10 +227,17 @@ public class MultiplayerManager : NetworkManager
         NetworkServer.AddPlayerForConnection(conn, player, playerControllerId);
     }
 
+    public void RegisterPlayer(Player player)
+    {
+        playerList.Add(player);
+        NetworkServer.SendToAll(ExtMsgType.State, new GameStateMessage(playerList, teamScores));
+    }
+
     //Only purpose of overriding this is to make it do nothing
     //The base method readies the scene & spawns the player immediately upon connection
     public override void OnClientConnect(NetworkConnection conn)
     {
+        client.RegisterHandler(ExtMsgType.State, OnStateUpdate);
     }
 
     //Only purpose of overriding is to properly manage the playerList
@@ -207,6 +252,13 @@ public class MultiplayerManager : NetworkManager
     public void SpawnClient()
     {
         ClientScene.AddPlayer(client.connection, 0, new SpawnMessage(localPlayerName, localPlayerTeam));
+    }
+
+    public void OnStateUpdate(NetworkMessage netMsg)
+    {
+        GameStateMessage msg = netMsg.ReadMessage<GameStateMessage>();
+        playerList = msg.playerList;
+        teamScores = msg.teamScores;
     }
 
     //This is a custom message to send name and team choices to the server
@@ -232,5 +284,62 @@ public class MultiplayerManager : NetworkManager
             name = reader.ReadString();
             team = reader.ReadInt16();
         }
+    }
+
+    class GameStateMessage : MessageBase
+    {
+        public List<Player> playerList;
+        public Dictionary<Team, int> teamScores;
+
+        public GameStateMessage()
+        {
+            playerList = new List<Player>();
+            teamScores = new Dictionary<Team, int>();
+        }
+
+        public GameStateMessage(List<Player> plyList, Dictionary<Team, int> scores)
+        {
+            playerList = plyList;
+            teamScores = scores;
+        }
+
+        public override void Serialize(NetworkWriter writer)
+        {
+            foreach(Team team in Enum.GetValues(typeof(Team)))
+            {
+                writer.Write(teamScores[team]);
+            }
+            writer.Write(playerList.Count);
+            foreach(Player player in playerList)
+            {
+                player.Serialize(writer);
+            }
+        }
+
+        public override void Deserialize(NetworkReader reader)
+        {
+            foreach (Team team in Enum.GetValues(typeof(Team)))
+            {
+                teamScores[team] = reader.ReadInt32();
+            }
+            int count = reader.ReadInt32();
+            for(int i=0; i< count; i++)
+            {
+                Player player = new Player();
+                player.Deserialize(reader);
+                playerList.Add(player);
+            }
+        }
+    }
+
+    public class KillMessage : MessageBase
+    {
+        public int bountyGained;
+    }
+
+    public class ExtMsgType
+    {
+        public static short State = MsgType.Highest + 1;
+        public static short Kill = MsgType.Highest + 2;
     }
 }

--- a/Twisted Sails/Assets/Scripts/MultiplayerManager.cs
+++ b/Twisted Sails/Assets/Scripts/MultiplayerManager.cs
@@ -90,9 +90,12 @@ public class MultiplayerManager : NetworkManager
     public Gamemode currentGamemode = Gamemode.TeamDeathmatch;
     public string localPlayerName;
     public Team localPlayerTeam;
+    public int pointsToWin;
     public List<Player> playerList;
     public Dictionary<Team, int> teamScores;
     public static MultiplayerManager instance;
+
+    
 
     private float gameRestartTimer;
 
@@ -157,7 +160,7 @@ public class MultiplayerManager : NetworkManager
     public void CheckEndGame()
     {
         foreach (Team team in Enum.GetValues(typeof(Team)))
-            if (teamScores[team] >= 10)
+            if (teamScores[team] >= pointsToWin)
             {
                 gameRestartTimer = 10;
                 foreach (Player player in playerList)

--- a/Twisted Sails/Assets/Scripts/NetworkHUD.cs
+++ b/Twisted Sails/Assets/Scripts/NetworkHUD.cs
@@ -22,6 +22,8 @@ public class NetworkHUD : MonoBehaviour
     public int offsetX;
     [SerializeField]
     public int offsetY;
+    [SerializeField]
+    public float messageDisplayDuration;
 
     int teamSelection;
     bool showScoreboard;
@@ -66,7 +68,7 @@ public class NetworkHUD : MonoBehaviour
             {
                 messageStack.RemoveAt(0);
                 if (messageStack.Count > 0)
-                    messageTimer = 2.5f;
+                    messageTimer = messageDisplayDuration;
                 else
                     messageTimer = 0;
             }
@@ -80,7 +82,7 @@ public class NetworkHUD : MonoBehaviour
         if (msg.bountyGained > 0)
             messageStack.Add("Bounty! +" + msg.bountyGained);
         if (messageTimer == 0)
-            messageTimer = 2.5f;
+            messageTimer = messageDisplayDuration;
     }
 
     void OnGUI()


### PR DESCRIPTION
Explanation of changed files:

Health.cs -- Small amounts of cleanup and changes to allow server to synchronize player states when a new player joins.

MultiplayerManager.cs -- Added a lot of code that has to do with synchronizing the current game state with all players. This is so that the players know what's going on: i.e. each team's score, each player's kills, deaths, etc. for the scoreboards and score displays. Also added new message types for transmitting this information, as well as transmitting score gain on kill so that it can be displayed by the NetworkHUD. The number of points needed by a team to win is defined by an editor variable.

NetworkHUD.cs -- Added code for displaying scoreboard and for the feed for recent score gains as defined in the design doc. Scoreboard is drawn over everything else as long as TAB is held down, and the player's row is slightly more opaque than the others. All information is synced with the server at all times. The duration in seconds that a message stays on the screen is defined by an editor variable.