### PR TITLE
Stat System: First Version & Revised Crew Management System

### DIFF
--- a/Twisted Sails/Assets/Prefabs/Canvas(Health).prefab
+++ b/Twisted Sails/Assets/Prefabs/Canvas(Health).prefab
@@ -1823,7 +1823,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 20, y: 5}
-  m_SizeDelta: {x: 50, y: 40}
+  m_SizeDelta: {x: 55, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000010538698928
 RectTransform:
@@ -1859,7 +1859,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 20, y: 5}
-  m_SizeDelta: {x: 50, y: 40}
+  m_SizeDelta: {x: 55, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000010825151130
 RectTransform:
@@ -2216,7 +2216,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 20, y: 5}
-  m_SizeDelta: {x: 50, y: 40}
+  m_SizeDelta: {x: 55, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000012408917136
 RectTransform:

--- a/Twisted Sails/Assets/Prefabs/Mileston2Boat.prefab
+++ b/Twisted Sails/Assets/Prefabs/Mileston2Boat.prefab
@@ -1174,7 +1174,6 @@ GameObject:
   - 4: {fileID: 4000012373711734}
   - 54: {fileID: 54000013705223800}
   - 114: {fileID: 114000012413589446}
-  - 114: {fileID: 114000012203035594}
   - 136: {fileID: 136000013548959800}
   - 114: {fileID: 114000010219481882}
   - 114: {fileID: 114000010556032994}
@@ -1182,6 +1181,7 @@ GameObject:
   - 114: {fileID: 114000011436452340}
   - 114: {fileID: 114000010202202694}
   - 114: {fileID: 114000010222649082}
+  - 114: {fileID: 114000011331728158}
   m_Layer: 8
   m_Name: Mileston2Boat
   m_TagString: Untagged
@@ -5417,10 +5417,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 82148e684e6b18142b2ef9910a029c4b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  fireRateStage: 0
+  attackStage: 0
   defenseStage: 0
   speedStage: 0
-  crewCount: 0
   attackButton: Attack Crew
   defenseButton: Defense Crew
   speedButton: Speed Crew
@@ -5556,6 +5555,23 @@ MonoBehaviour:
   fireDelay: 1
   projectileSpeed: 20
   attackStat: 1
+--- !u!114 &114000011331728158
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013458966376}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d80cea8be5c26d48b86dcd4bc5e4d0c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  attackBar: {fileID: 0}
+  defenseBar: {fileID: 0}
+  speedBar: {fileID: 0}
+  attackText: {fileID: 0}
+  defenseText: {fileID: 0}
+  speedText: {fileID: 0}
 --- !u!114 &114000011401448514
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -5584,6 +5600,7 @@ MonoBehaviour:
   health: 100
   healthText: {fileID: 0}
   healthSlider: {fileID: 0}
+  healthPackAmount: 25
   sinkSpeed: 1
   sinkAngle: 40
   secondsToRespawn: 8
@@ -5595,7 +5612,6 @@ MonoBehaviour:
   explosion: {fileID: 1000011769946516, guid: 8af0c4ff01de10c4a9980db85d6bf910, type: 2}
   spawnPoint: {x: 0, y: 0, z: 0}
   defenseStat: 0
-  healthPackAmount: 25
 --- !u!114 &114000011472782010
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -5666,26 +5682,6 @@ MonoBehaviour:
   fireDelay: 1
   projectileSpeed: 20
   attackStat: 1
---- !u!114 &114000012203035594
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000013458966376}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f995605d3062064b98d8e45139f8c2e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  currentSpeed: 0
-  currentFireRate: 0
-  currentDefense: 0
-  currentSpeedStage: 0
-  currentFireRateStage: 0
-  currentDefenseStage: 0
-  attackButton: Attack Crew
-  defenseButton: Defense Crew
-  speedButton: Speed Crew
 --- !u!114 &114000012413589446
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Twisted Sails/Assets/Scripts/CrewManagementThreeStage.cs
+++ b/Twisted Sails/Assets/Scripts/CrewManagementThreeStage.cs
@@ -1,8 +1,4 @@
-﻿using UnityEngine;
-using UnityEngine.UI;
-using UnityEngine.Networking;
-
-/**
+﻿/**
 // This version of the Crew Management system uses a three-stage system as opposed to the
 // plus-minus system originally created. The player will have three points (crew members)
 // to allocate to their ship at any point in the match. When all three points are allocated,
@@ -14,17 +10,9 @@ using UnityEngine.Networking;
 //              raises the multiplier by one. Due to this, stats should not have a negative
 //              effect (drop below one).
 
-// Fire Rate:   Influences the fire delay of the ship's cannons. The lower the fireRateStage,
-//              the faster the cannons should be able to fire.
-//              The BroadsideCannonFireNetworked script uses attackMultiplier.
-
-// Defense:     Influences damage calculation. The lower the defenseStage, the less damage a
-//              ship takes from the enemy.
-//              The Health script uses defenseMultiplier.
-
-// Speed:       Influences the acceleration of the ship. The higher the speedStage, the faster
-//              the ship should move.
-//              The BoatMovementNetworked script uses speedMultiplier.
+// Attack:      Influences the fire delay of the ship's cannons.
+// Defense:     Influences damage calculation.
+// Speed:       Influences the acceleration of the ship.
 
 // CrewCount:   Keeps track of the current amount of crew members (points) available.
 //              Starting amount and maximum are three points, and points can be regained by
@@ -41,56 +29,43 @@ using UnityEngine.Networking;
 // Update:      Erick Ramirez Cordero
 // Date:        January 6, 2017
 // Description: Added ResetStats function.
+
+// Update:      Erick Ramirez Cordero
+// Date:        January 30, 2017
+// Description: Refactored the code to send stat modifications to the new StatSystem script
 */
+
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.Networking;
 
 public class CrewManagementThreeStage : NetworkBehaviour
 {
     // Current Stage Variables
     [Header ("Stage Variables")]
-    public int fireRateStage;
+    public int attackStage;
     public int defenseStage;
     public int speedStage;
-    public int crewCount;
+    private int statChange;
+    private int crewCount;
 
-    public const int CREW_MIN = 1;
-    public const int CREW_MAX = 4;
-
-    // Multiplier Variables
-    [Header ("Multiplier Variables")]
-    public float attackMultiplier;
-    public float defenseMultiplier;
-    public float speedMultiplier;
-    public float multiplier = 1;
-    private const float BASE_MULTIPLIER = 1.0f;
+    private const float STAGE_MULTIPLIER = 0.5f;
+    private const int CREW_MIN = 1;
+    private const int CREW_MAX = 4;
 
     // Timer variables
-    private float cooldown = 3.0f;
     private float cooldownTimer;
+    private const float COOLDOWN_LIMIT = 3.0f;
 
     // User Interface Variables
-    [Header ("UI / Input Variables")]
+    [Header ("Input Variables")]
     public string attackButton = "Attack Crew"; // At the moment set to '1'
     public string defenseButton = "Defense Crew"; // At the moment set to '2'
     public string speedButton = "Speed Crew"; // At the moment set to '3'
     public string resetButton = "Reset Crew"; // At the moment set to '4'
+    public Text crewText;
 
-    private Slider attackBar;
-    private Slider defenseBar;
-    private Slider speedBar;
-
-    private Text attackText;
-    private Text defenseText;
-    private Text speedText;
-    private Text counterText;
-
-    // Scripts influenced by Crew Management
-    private Health healthScript;
-    private BoatMovementNetworked boatScript;
-
-    // Set to the number of cannons on the ship (Currently 8)
-    private const int CANNON_COUNT = 8;
-    private BroadsideCannonFireNetworked[] fireScripts = new BroadsideCannonFireNetworked[CANNON_COUNT];
-
+    private StatSystem statSystem;
     private bool debugFlag = true;
 
     // Use this for initialization
@@ -98,37 +73,16 @@ public class CrewManagementThreeStage : NetworkBehaviour
     {
         if (isLocalPlayer)
         {
-            // Initialize scripts and UI
-            healthScript = GetComponentInChildren<Health>();
-            boatScript = GetComponentInChildren<BoatMovementNetworked>();
-            fireScripts = GetComponentsInChildren<BroadsideCannonFireNetworked>();
-            
-            Transform crewUI = GameObject.FindGameObjectWithTag("CrewManagementUI").transform;
-            Transform attackUI = crewUI.FindChild("AttackCrewUI");
-            Transform defenseUI = crewUI.FindChild("DefenseCrewUI");
-            Transform speedUI = crewUI.FindChild("SpeedCrewUI");
+            statSystem = GetComponentInChildren<StatSystem>();
+            crewText = GameObject.FindGameObjectWithTag("CrewManagementUI").GetComponentInChildren<Text>();
 
-            attackBar = attackUI.GetComponentInChildren<Slider>();
-            defenseBar = defenseUI.GetComponentInChildren<Slider>();
-            speedBar = speedUI.GetComponentInChildren<Slider>();
+            attackStage = CREW_MIN;
+            defenseStage = CREW_MIN;
+            speedStage = CREW_MIN;
 
-            attackText = attackUI.GetComponentInChildren<Text>();
-            defenseText = defenseUI.GetComponentInChildren<Text>();
-            speedText = speedUI.GetComponentInChildren<Text>();
-            counterText = crewUI.GetComponentInChildren<Text>();
-
-            // Initialize UI bar min / max values
-            attackBar.minValue = CREW_MIN;
-            attackBar.maxValue = CREW_MAX;
-
-            defenseBar.minValue = CREW_MIN;
-            defenseBar.maxValue = CREW_MAX;
-
-            speedBar.minValue = CREW_MIN;
-            speedBar.maxValue = CREW_MAX;
-
-            // Call ResetStats to initialize stages, multipliers, and UI current values
-            ResetStats();
+            crewCount = CREW_MAX - 1;
+            crewText.text = "Available Crew: " + crewCount;
+            cooldownTimer = 0;
         }
     }
 
@@ -136,9 +90,9 @@ public class CrewManagementThreeStage : NetworkBehaviour
     /// In the Update event, the script checks if the cooldown timer has reached its
     /// end. If not, the cooldown timer is incremented by Time.deltaTime.
     /// Otherwise, the script checks for player input. If a crew button is selected,
-    /// then the function StatUpdate is called to update the stat, the stat is updated
-    /// in the respective script, the function DisplayUpdate is called to update the UI,
-    /// and the cooldown timer is reset.
+    /// then the function StatUpdate is called to update the stat in relation to the
+    /// number of crew members available. If any change does occur, the modification
+    /// goes to the StatSystem.
     /// </summary>
 
     // Update is called once per frame
@@ -146,40 +100,46 @@ public class CrewManagementThreeStage : NetworkBehaviour
     {
         if (isLocalPlayer)
         {
-            if (cooldownTimer < cooldown)
+            if (cooldownTimer < COOLDOWN_LIMIT)
             { cooldownTimer += Time.deltaTime; }
 
             else
             {
                 if (Input.GetButtonDown(attackButton))
                 {
-                    StatUpdate(ref fireRateStage, ref attackMultiplier);
+                    statChange = StatUpdate(ref attackStage);
 
-                    for (int i = 0; i < CANNON_COUNT; i++)
-                    { fireScripts[i].attackStat = 1 / attackMultiplier; }
-
-                    DisplayUpdate(ref fireRateStage, ref attackBar, ref attackText);
-                    cooldownTimer = 0;
+                    if (statChange != 0)
+                    {
+                        statSystem.AlterAttack(STAGE_MULTIPLIER * statChange);
+                        cooldownTimer = 0;
+                    }
                 }
 
                 else if (Input.GetButtonDown(defenseButton))
                 {
-                    StatUpdate(ref defenseStage, ref defenseMultiplier);
-                    healthScript.defenseStat = 1 / defenseMultiplier;
-                    DisplayUpdate(ref defenseStage, ref defenseBar, ref defenseText);
-                    cooldownTimer = 0;
+                    statChange = StatUpdate(ref defenseStage);
+
+                    if (statChange != 0)
+                    {
+                        statSystem.AlterDefense(STAGE_MULTIPLIER * statChange);
+                        cooldownTimer = 0;
+                    }
                 }
 
                 else if (Input.GetButtonDown(speedButton))
                 {
-                    StatUpdate(ref speedStage, ref speedMultiplier);
-                    boatScript.speedStat = speedMultiplier;
-                    DisplayUpdate(ref speedStage, ref speedBar, ref speedText);
-                    cooldownTimer = 0;
+                    statChange = StatUpdate(ref speedStage);
+
+                    if (statChange != 0)
+                    {
+                        statSystem.AlterSpeed(STAGE_MULTIPLIER * statChange);
+                        cooldownTimer = 0;
+                    }
                 }
 
                 else if (Input.GetButtonDown(resetButton))
-                { ResetStats(); }
+                { ResetStages(); }
             }
         }
 	}
@@ -190,81 +150,51 @@ public class CrewManagementThreeStage : NetworkBehaviour
     /// one point. If currentCrew is at or below the minimum, then currentCrew is reset to the
     /// minimum plus one point that is taken away from the stat.
     /// </summary>
-    /// <param name="stat"> The stat's stage to be updated </param>
-    /// <param name="statMultiplier"> The stat multiplier to be updated </param>
+    /// <param name="stage"> The stat's stage to be updated </param>
 
-    void StatUpdate(ref int stat, ref float statMultiplier)
+    int StatUpdate(ref int stage)
     {
-        if (crewCount >= CREW_MIN && stat < CREW_MAX)
+        if (crewCount >= CREW_MIN && stage < CREW_MAX)
         {
-            stat++;
-            statMultiplier += multiplier;
+            stage++;
             crewCount--;
+            crewText.text = "Available Crew: " + crewCount;
+            return 1;
         }
 
-        else if (stat > CREW_MIN)
+        else if (stage > CREW_MIN)
         {
-            stat--;
-            statMultiplier -= multiplier;
-            crewCount = CREW_MIN;
+            stage--;
+            crewCount++;
+            crewText.text = "Available Crew: " + crewCount;
+            return -1;
         }
 
-        // Check to ensure stat has not fallen below the min or max
-        if (stat < CREW_MIN) { stat = CREW_MIN; }
-        else if (stat > CREW_MAX) { stat = CREW_MAX; }
-
-        if (debugFlag)
-        {
-            Debug.Log("Debug - Stat after update: " + stat);
-            Debug.Log("Debug - Stat Multiplier: " + statMultiplier);
-            Debug.Log("Debug - Crew count: " + crewCount);
-        }
+        else
+        { return 0; }
     }
 
     /// <summary>
-    /// DisplayUpdate updates the Crew Management portion of the UI with current
-    /// stat information.
-    /// </summary>
-    /// <param name="stat"> The stat's stage </param>
-    /// <param name="statBar"> The stat's UI slider </param>
-    /// <param name="statText"> The stat's UI text </param>
-
-    void DisplayUpdate(ref int stat, ref Slider statBar, ref Text statText)
-    {
-        statBar.value = stat;
-        statText.text = "Stage: " + stat;
-        counterText.text = "Available Crew: " + crewCount;
-    }
-
-    /// <summary>
-    /// ResetStats is called when the crew management system is first instantiated
-    /// and when the reset key is pressed.
+    /// ResetStages is called when when the reset key is pressed. 
+    /// The stat system is first updated with the modification of:
+    ///     -(stage - 1) * multiplier
+    /// Then the stages, crew count, and timer are reset.
     /// </summary>
     
-    void ResetStats()
+    void ResetStages()
     {
-        // Reset stages, multipliers, and timer
-        fireRateStage = CREW_MIN;
+        // First reset ship's stats
+        statSystem.AlterAttack(-(attackStage - 1) * STAGE_MULTIPLIER);
+        statSystem.AlterDefense(-(defenseStage - 1) * STAGE_MULTIPLIER);
+        statSystem.AlterSpeed(-(speedStage - 1) * STAGE_MULTIPLIER);
+
+        // Reset stages and timer
+        attackStage = CREW_MIN;
         defenseStage = CREW_MIN;
         speedStage = CREW_MIN;
-
-        attackMultiplier = BASE_MULTIPLIER;
-        defenseMultiplier = BASE_MULTIPLIER;
-        speedMultiplier = BASE_MULTIPLIER;
-
+        
         crewCount = CREW_MAX - 1;
+        crewText.text = "Available Crew: " + crewCount;
         cooldownTimer = 0;
-
-        // Reset variables in other scripts
-        for (int i = 0; i < CANNON_COUNT; i++)
-        { fireScripts[i].attackStat = 1 / attackMultiplier; }
-
-        healthScript.defenseStat = 1 / defenseMultiplier;
-        boatScript.speedStat = speedMultiplier;
-
-        // Reset UI
-        DisplayUpdate(ref fireRateStage, ref attackBar, ref attackText);
-        DisplayUpdate(ref defenseStage, ref defenseBar, ref defenseText);
-        DisplayUpdate(ref speedStage, ref speedBar, ref speedText);
     }
 }

--- a/Twisted Sails/Assets/Scripts/StatSystem.cs
+++ b/Twisted Sails/Assets/Scripts/StatSystem.cs
@@ -1,0 +1,193 @@
+﻿/**
+// The Stat System will serve as the general system for the statistics of different ships
+// and mechanics that rely on altering ship stats (i.e. Crew Management). Three stats are
+// available:
+
+//      Attack  - Influences Fire Rate of cannons       - BroadsideCannonFireNetworked Scripts
+//      Defense - Influences amount of damage taken     - Health Script
+//      Speed   - Influences movement of the ship       - BoatMovementNetworked Script
+
+// Each stat has a BASE constant to denote the starting value. These values can be changed
+// for ships to have unique stats. To alter the stats of a ship during gameplay, the 
+// appropriate MOD variable should be changed by calling one of the Alter Functions. The
+// stats are calculated as:
+
+//      Attack   = BASE / MOD
+//      Defense  = BASE * MOD
+//      Speed    = BASE / MOD
+
+// Author:  Erick Ramirez Cordero
+// Date:    January 22, 2017
+*/
+
+using UnityEngine;
+using UnityEngine.Networking;
+using UnityEngine.UI;
+
+public class Stat : NetworkBehaviour
+{
+    public float currentAttack
+    {
+        get;
+        protected set;
+    }
+
+    public float currentDefense
+    {
+        get;
+        protected set;
+    }
+
+    public float currentSpeed
+    {
+        get;
+        protected set;
+    }
+
+    [Header("Ship Stats")]
+    private float attackMod;
+    private float defenseMod;
+    private float speedMod;
+
+    private const float BASE_ATTACK = 1.0f;
+    private const float BASE_DEFENSE = 1.0f;
+    private const float BASE_SPEED = 1.0f;
+
+    private const float BASE_MOD = 1.0f;
+    private const float MOD_MIN = 1.0f;
+    private const float MOD_MAX = 5.0f;
+
+    [Header("UI / Input Variables")]
+    private Slider attackBar;
+    private Slider defenseBar;
+    private Slider speedBar;
+
+    private Text attackText;
+    private Text defenseText;
+    private Text speedText;
+
+    // Scripts influenced by Crew Management
+    private Health healthScript;
+    private BoatMovementNetworked boatScript;
+
+    // Set to the number of cannons on the ship (Currently 8)
+    private const int CANNON_COUNT = 8;
+    private BroadsideCannonFireNetworked[] fireScripts = new BroadsideCannonFireNetworked[CANNON_COUNT];
+
+    private bool debugFlag = true;
+
+    void Awake ()
+    {
+        if (isLocalPlayer)
+        {
+            // Initialize scripts and UI components
+            healthScript = GetComponentInChildren<Health>();
+            boatScript = GetComponentInChildren<BoatMovementNetworked>();
+            fireScripts = GetComponentsInChildren<BroadsideCannonFireNetworked>();
+
+            Transform crewUI = GameObject.FindGameObjectWithTag("CrewManagementUI").transform;
+            Transform attackUI = crewUI.FindChild("AttackCrewUI");
+            Transform defenseUI = crewUI.FindChild("DefenseCrewUI");
+            Transform speedUI = crewUI.FindChild("SpeedCrewUI");
+
+            attackBar = attackUI.GetComponentInChildren<Slider>();
+            defenseBar = defenseUI.GetComponentInChildren<Slider>();
+            speedBar = speedUI.GetComponentInChildren<Slider>();
+
+            attackText = attackUI.GetComponentInChildren<Text>();
+            defenseText = defenseUI.GetComponentInChildren<Text>();
+            speedText = speedUI.GetComponentInChildren<Text>();
+
+            // Initialize Stats
+
+            currentAttack = BASE_ATTACK;
+            currentDefense = BASE_DEFENSE;
+            currentSpeed = BASE_SPEED;
+
+            for (int i = 0; i < CANNON_COUNT; i++)
+            { fireScripts[i].attackStat = currentAttack; }
+
+            healthScript.defenseStat = currentDefense;
+            boatScript.speedStat = currentSpeed;
+
+            // Initialize UI values
+            attackBar.minValue = BASE_ATTACK / MOD_MIN;
+            attackBar.maxValue = BASE_ATTACK / MOD_MAX;
+            attackBar.value = currentAttack;
+            attackText.text = "Attack: " + currentAttack;
+
+            defenseBar.minValue = BASE_DEFENSE * MOD_MIN;
+            defenseBar.maxValue = BASE_DEFENSE * MOD_MAX;
+            defenseBar.value = currentDefense;
+            defenseText.text = "Defense: " + currentDefense;
+
+            speedBar.minValue = BASE_SPEED / MOD_MIN;
+            speedBar.maxValue = BASE_SPEED / MOD_MAX;
+            speedBar.value = currentSpeed;
+            speedText.text = "Speed: " + currentSpeed;
+        }
+	}
+	
+    /*
+	void Update ()
+    {
+
+	}
+    */
+
+    /// <summary>
+    /// AlterAttack is to be called when another script wants to alter the attack stat
+    /// of the ship. The new modification is added to attackMod, and the currentAttack
+    /// is calculated using the updated attackMod. Afterwards the appropriate script(s)
+    /// and UI elements are updated with the new currentAttack.
+    /// </summary>
+    /// <param name="newMod">   The new modification to be applied  </param>
+    public void AlterAttack(float newMod)
+    {
+        attackMod += newMod;
+        CheckModLimits(ref attackMod);
+        currentAttack = BASE_ATTACK / attackMod;
+
+        for (int i = 0; i < CANNON_COUNT; i++)
+        { fireScripts[i].attackStat = currentAttack; }
+
+        attackBar.value = currentAttack;
+        attackText.text = "Attack: " + currentAttack;
+    }
+
+    public void AlterDefense(float newMod)
+    {
+        defenseMod += newMod;
+        CheckModLimits(ref defenseMod);
+        currentDefense = BASE_DEFENSE * defenseMod;
+
+        healthScript.defenseStat = currentDefense;
+        defenseBar.value = currentDefense;
+        defenseText.text = "Defense: " + currentDefense;
+    }
+
+    public void AlterSpeed(float newMod)
+    {
+        speedMod += newMod;
+        CheckModLimits(ref speedMod);
+        currentSpeed = BASE_SPEED / speedMod;
+
+        boatScript.speedStat = currentSpeed;
+        speedBar.value = currentSpeed;
+        speedText.text = "Speed: " + currentSpeed;
+    }
+
+    /// <summary>
+    /// This function checks if the stat modification in question exceeds the maximum
+    /// or falls below the minimum modification allowed, making corrections if needed.
+    /// </summary>
+    /// <param name="statMod"></param>
+    private void CheckModLimits(ref float statMod)
+    {
+        if (statMod > MOD_MAX)
+        { statMod = MOD_MAX; }
+
+        else if (statMod < MOD_MIN)
+        { statMod = MOD_MIN; }
+    }
+}

--- a/Twisted Sails/Assets/Scripts/StatSystem.cs.meta
+++ b/Twisted Sails/Assets/Scripts/StatSystem.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4d80cea8be5c26d48b86dcd4bc5e4d0c
+timeCreated: 1485145785
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Stat System: First Version
## Description
The Stat System will serve as the general system for all stat-related modifications to the ship. Other scripts, such as the Crew Management System, should call the functions of the Stat System in order to influence:
- Attack: Influences Fire Rate of cannons
  - BroadsideCannonFireNetworked Scripts
- Defense: Influences amount of damage taken
  - Health Script
- Speed: Influences movement of the ship
  - BoatMovementNetworked Script
## Variables
Each stat has a BASE constant to denote the starting value. These values can be edited (after a copy of the script is made) for different ship types to have unique stats.
- BASE_ATTACK
- BASE_DEFENSE
- BASE_SPEED

To alter the stats of a ship during gameplay, the appropriate MOD variable should be changed by calling one of the Alter Stat Functions. The Alter Stat Functions take the new modification (float) as the argument. The new modification should be positive if it is a buff or negative if it is a debuff. Only pass the current modification (i.e. not a grand total) since the Stat System keeps track of all stat modifications during gameplay.

The stats are calculated in the Alter Stat Functions as:
- *Current Attack = 1 / (BASE_ATTACK + attackMod)*
- *Current Defense = 1 / (BASE_DEFENSE + defenseMod)*
- *Current Speed = BASE_SPEED + speedMod*

It should also be noted that other scripts can "get" the current stats of the ship, but other scripts cannot directly "set" the stats; they MUST use the Alter Stat Functions.
## Crew Management System Revision
The Crew Management (Three Stage) System has been revised to work with the new Stat System. The three stage system is still the same, but code was removed and modified for the script to call the Alter Stat Functions of the Stat System.
### Other notes:
- STAGE_MULTIPLIER is a constant that denotes how much a stat changes per stage
- The cooldown limit was renamed COOLDOWN_LIMIT
- The only UI element the Crew Management system has is the Crew Counter Text
- StatUpdate() returns an int to determine if the modification is a buff or debuff before the Alter Stat Function is called
  - If the int is zero, then no modification needs to be made
- ResetStage() resets the stats by using this equation:
  - *(-1)(stage - 1) * STAGE_MULTIPLIER*
## Example of Stat System
A few seconds into a match, the player first selects a Speed Buff from the Crew Management system.
- Speed Stage increases from 1 to 2
- Crew Count decreases from 3 to 2
- StatChange() returns 1 to denote a buff
  - STAGE_MULTIPLIER is set to 0.5, so the buff will increase speed by +0.5

At this point, the Crew Management System calls the Stat System function *AlterSpeed(float newMod)*, passing +0.5 as the new mod. When this function call ends, the Crew Management System resets the cooldown timer.
- Speed Mod increases from 0  to 0.5
  - *Mathf.Clamp()* checks to make sure the Mod does not fall below MOD_MIN or exceed MOD_MAX 
- Current Speed = BASE_SPEED + Speed Mod
  - BASE_SPEED is set to 1, so the current speed is now 1.5
- The Boat Movement Script, UI Speed Slider, and UI Speed Text are updated with the new stat

## Other Modifications
The Boat Prefab and Crew Management portion of the UI were modified to work with the new Systems. Boat prefabs should have BOTH the StatSystem and CrewManagementThreeStage scripts. To customize the base stats of a ship, copy the StatSystem script, change the BASE constants, and place the new script on the ship.