### PR TITLE
Weapon System Enhancements

### DIFF
--- a/Twisted Sails/Assets/Prefabs/Mileston2Boat.prefab
+++ b/Twisted Sails/Assets/Prefabs/Mileston2Boat.prefab
@@ -315,7 +315,7 @@ GameObject:
   - 136: {fileID: 136000011209803362}
   - 23: {fileID: 23000012529586806}
   - 114: {fileID: 114000013702980854}
-  - 114: {fileID: 114000010498800408}
+  - 114: {fileID: 114000011926137916}
   m_Layer: 8
   m_Name: Cannon
   m_TagString: Untagged
@@ -1492,7 +1492,6 @@ GameObject:
   - 23: {fileID: 23000010017654580}
   - 114: {fileID: 114000013310386108}
   - 114: {fileID: 114000012589808420}
-  - 114: {fileID: 114000011472782010}
   m_Layer: 8
   m_Name: Cannon (8)
   m_TagString: SwivelGun
@@ -5455,20 +5454,6 @@ MonoBehaviour:
   fireDelay: 1
   projectileSpeed: 20
   attackStat: 1
---- !u!114 &114000010498800408
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000010875970672}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9bd3a1816f244654ba7d67a6e9ae0c3d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  fireDelay: 1
-  projectileSpeed: 20
-  attackStat: 1
 --- !u!114 &114000010556032994
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5494,6 +5479,17 @@ MonoBehaviour:
   cannonFireKey: 32
   swivelGunFireKey: 323
   cannonBall: {fileID: 1000013620427708, guid: 999d70260556d6a4d99c8c6ca2089051, type: 2}
+  cannonScripts:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  swivelGunScripts: []
 --- !u!114 &114000010825273558
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -5585,20 +5581,6 @@ MonoBehaviour:
   shipCamera: {fileID: 0}
   projectileSpeed: 10
   scaleFactor: 0.25
---- !u!114 &114000011472782010
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000014178595284}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9bd3a1816f244654ba7d67a6e9ae0c3d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  fireDelay: 1
-  projectileSpeed: 20
-  attackStat: 1
 --- !u!114 &114000011590326226
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -5624,6 +5606,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5917c00c96fc8a744ac7625256ac3f38, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &114000011926137916
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010875970672}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9bd3a1816f244654ba7d67a6e9ae0c3d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fireDelay: 1
+  projectileSpeed: 20
+  attackStat: 1
 --- !u!114 &114000011938982268
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -5793,6 +5789,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a405163aa8d259448aba12f3179ebe3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  fireDelay: 1
+  projectileSpeed: 20
+  attackStat: 1
 --- !u!114 &114000012915758064
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Twisted Sails/Assets/Scripts/BoatMovementNetworked.cs
+++ b/Twisted Sails/Assets/Scripts/BoatMovementNetworked.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEngine.Networking;
-using System.Collections;
+using System.Linq;
+using System.Collections.Generic;
 
 /************************** BOAT MOVEMENT SCRIPT *******************************
  * This script controls the movement of the boat, now with key bindings and 
@@ -68,11 +69,10 @@ public class BoatMovementNetworked : NetworkBehaviour
 	}
 	private BoatInput KeysDown;
 
-	//List of cannons - Assume NINE cannons (8 broadside cannons + 1 swivel gun)
 	public GameObject cannonBall;
-	private BroadsideCannonFireNetworked[] cannonScripts 
-		= new BroadsideCannonFireNetworked[9];
-    private SwivelGun swivelGunScript;
+    //List of cannons
+    public List<BroadsideCannonFireNetworked> cannonScripts;
+    public List<SwivelGun> swivelGunScripts;
 	//Allocate space for Position, and Velocity for firing cannonballs
 	private static Vector3 cannonPosition, cannonBallVelocity;
 
@@ -96,8 +96,8 @@ public class BoatMovementNetworked : NetworkBehaviour
         boatCam.boatToFollow = this.gameObject;
 
         //Get cannon scripts from all cannons
-        cannonScripts = this.GetComponentsInChildren<BroadsideCannonFireNetworked>();
-        swivelGunScript = this.GetComponentInChildren<SwivelGun>();
+        cannonScripts = new List<BroadsideCannonFireNetworked>(this.GetComponentsInChildren<BroadsideCannonFireNetworked>().Where(t => t.GetType() != typeof(SwivelGun)));
+        swivelGunScripts = new List<SwivelGun>(this.GetComponentsInChildren<SwivelGun>());
     }
 
 	//Get input for player
@@ -114,13 +114,13 @@ public class BoatMovementNetworked : NetworkBehaviour
 
             if (KeysDown.fireSwivelGun)
             {
-                foreach (BroadsideCannonFireNetworked cScript in cannonScripts)
+                foreach (SwivelGun sScript in swivelGunScripts)
                 {
-                    if (cScript.gameObject.tag == "SwivelGun" && cScript.CanFire())
+                    if (sScript.CanFire())
                     {
                         //(Scale is static to CannonBallNetworked script)
                         //Pass information to server and spawn cannonball on all cients
-                        CmdFire(cScript.createCannonBall(cannonBall, this.GetComponent<NetworkIdentity>().netId));
+                        CmdFire(sScript.createCannonBall(cannonBall, this.GetComponent<NetworkIdentity>().netId));
                     }
                 }
             }
@@ -129,7 +129,7 @@ public class BoatMovementNetworked : NetworkBehaviour
 			{
 				foreach (BroadsideCannonFireNetworked cScript in cannonScripts)
 				{
-					if (cScript.gameObject.tag != "SwivelGun" && cScript.CanFire())
+					if (cScript.CanFire())
 					{
 						//(Scale is static to CannonBallNetworked script)
                         //Pass information to server and spawn cannonball on all cients
@@ -181,9 +181,14 @@ public class BoatMovementNetworked : NetworkBehaviour
 			boat.AddForceAtPosition(forceDirection * acceleration, transform.position + transform.forward * boatPropulsionPointOffset, ForceMode.Acceleration);
 		}
 
-        //Asks the boat's attached swivel gun (if it exists) to update its position based on the rotation of the boat's camera
-        if(swivelGunScript != null)
-            swivelGunScript.updateRotation(boatCam.transform);
+        //Asks the boat's attached swivel guns (if they exist) to update their rotations based on the rotation of the boat's camera
+        if(swivelGunScripts.Count != 0)
+        {
+            foreach(SwivelGun sScript in swivelGunScripts)
+            {
+                sScript.updateRotation(boatCam.transform);
+            }
+        }
 	}
 
     //Called by client, runs on server.

--- a/Twisted Sails/Assets/Scripts/SwivelGun.cs
+++ b/Twisted Sails/Assets/Scripts/SwivelGun.cs
@@ -7,7 +7,12 @@ using System.Collections;
 // Edward Borroughs 
 // Version 2/1/2016
 
-public class SwivelGun : MonoBehaviour {
+// Update:      Edward Borroughs
+// Date:        February 16, 2016
+// Description: The SwivelGun class now extends BroadsideCannonFireNetworked and can be treated as
+//              a broadside cannon with more functionality.
+
+public class SwivelGun : BroadsideCannonFireNetworked {
 
     public void updateRotation(Transform objTransform)
     {


### PR DESCRIPTION
The colliders on the cannons of the Milestone2Boat prefab were disabled because the
cannonballs were colliding with the cannons when they were instantiated
and there is no reason for them to have colliders anyways.
BoatMovementNetworked was changed so the boats will work with any number
of cannons and swivel guns. SwivelGun was changed to extend
BroadsideCannonNetworked so the only difference between a broadside
cannon and a swivel gun is which of the two scripts is attached making it much easier to add swivel guns to a boat.