### PR TITLE
Networking fixes & some polish

### DIFF
--- a/Twisted Sails/Assets/Scenes/Title Screen.unity
+++ b/Twisted Sails/Assets/Scenes/Title Screen.unity
@@ -3413,9 +3413,10 @@ MonoBehaviour:
   lobbyPrefab: {fileID: 1024232112829116, guid: a40aeac91e14e7c45a756cc922550a6a,
     type: 2}
   inGameScene: MainLevel
+  localConnectionId: 0
   playableShips:
-  - {fileID: 1000013458966376, guid: 93df41ee14972a04bbb4fd2e59b8f2ee, type: 2}
-  - {fileID: 1000013458966376, guid: e0e164241721d3143a13bc6ff7b6d9b5, type: 2}
+  - {fileID: 1000013458966376, guid: 9792aedbd70d08d4ca4ce5d490f71f4b, type: 2}
+  - {fileID: 1000013458966376, guid: 74c6dd3ab10f9c04c95783e40e35c88d, type: 2}
   - {fileID: 1000013458966376, guid: a35872d6be62b8c4ebd864b495a4048a, type: 2}
   - {fileID: 0}
 --- !u!4 &1764216002

--- a/Twisted Sails/Assets/Scripts/MultiplayerManager.cs
+++ b/Twisted Sails/Assets/Scripts/MultiplayerManager.cs
@@ -60,6 +60,11 @@ using System;
 // Date:        2/24/2017
 // Description: Minor changes to work with new lobby.
 
+// Developer:   Kyle Aycock
+// Date:        3/23/2017
+// Description: Fixed bug having to do with Unity networking keeping separate
+//              connectionIds on client and server.
+
 public class MultiplayerManager : NetworkManager
 {
     public Gamemode currentGamemode;
@@ -71,6 +76,7 @@ public class MultiplayerManager : NetworkManager
     public int[] teamScores;
     public GameObject lobbyPrefab;
     public string inGameScene;
+    public int localConnectionId;
 
     public GameObject[] playableShips;
 
@@ -387,6 +393,7 @@ public class MultiplayerManager : NetworkManager
             playerObj.GetComponent<PlayerIconController>().playerName = playerName;
             playerObj.GetComponent<PlayerIconController>().playerTeam = playerTeam;
             playerObj.GetComponent<PlayerIconController>().playerShip = playerShip;
+            playerObj.GetComponent<PlayerIconController>().connectionId = conn.connectionId;
         }
         else {
             //We are spawning a ship in game

--- a/Twisted Sails/Assets/Scripts/NetworkHUD.cs
+++ b/Twisted Sails/Assets/Scripts/NetworkHUD.cs
@@ -16,6 +16,12 @@ using UnityEngine.Networking;
 // Date:        2/1/2017
 // Description: Adapted to new team system
 
+// Developer:   Kyle Aycock
+// Date:        3/23/2017
+// Description: Allow TAB playerlist only in game
+//              Disabled unnecessary debug function
+//              Hide redundant info display in top left
+
 [RequireComponent(typeof(NetworkManager))]
 public class NetworkHUD : MonoBehaviour
 {
@@ -60,7 +66,7 @@ public class NetworkHUD : MonoBehaviour
                 else
                     manager.StopClient();
             }
-            if (Input.GetKey(KeyCode.Tab))
+            if (Input.GetKey(KeyCode.Tab) && !MultiplayerManager.IsLobby())
                 showScoreboard = true;
             else
                 showScoreboard = false;
@@ -77,10 +83,10 @@ public class NetworkHUD : MonoBehaviour
                     messageTimer = 0;
             }
         }
-        if (Input.GetKey(KeyCode.P))
+        /*if (Input.GetKey(KeyCode.P))
         {
             showDebug = true;
-        }
+        }*/
     }
 
     public void OnKill(NetworkMessage netMsg)
@@ -127,7 +133,10 @@ public class NetworkHUD : MonoBehaviour
         }
         else
         {*/
-        if (NetworkServer.active)
+
+
+        //Uncomment this code to display the server address and port in the top left
+        /*if (NetworkServer.active)
         {
             GUI.Label(new Rect(xpos, ypos, 300, 20), "Server: port=" + manager.networkPort);
             ypos += spacing;
@@ -136,7 +145,7 @@ public class NetworkHUD : MonoBehaviour
         {
             GUI.Label(new Rect(xpos, ypos, 300, 20), "Client: address=" + manager.networkAddress + " port=" + manager.networkPort);
             ypos += spacing;
-        }
+        }*/
         //}
 
         //This disabled code was where the player specified name/team in the HUD
@@ -158,7 +167,8 @@ public class NetworkHUD : MonoBehaviour
         }*/
 
 
-        if (NetworkServer.active || manager.IsClientConnected())
+        //Uncomment this code to show basic player info and stop button in top left
+        /*if (NetworkServer.active || manager.IsClientConnected())
         {
             if (ClientScene.ready)
             {
@@ -172,8 +182,7 @@ public class NetworkHUD : MonoBehaviour
                 manager.StopHost();
             }
             ypos += spacing;
-
-        }
+        }*/
 
         if (showDebug)
         {

--- a/Twisted Sails/Assets/Scripts/PlayerIconController.cs
+++ b/Twisted Sails/Assets/Scripts/PlayerIconController.cs
@@ -32,6 +32,10 @@ using System.Collections.Generic;
 // Date:        2/24/2017
 // Description: Revamped lobby flow and usage of this script
 
+// Developer:   Kyle Aycock
+// Date:        3/23/2017
+// Description: Fixed bug having to do with Unity keeping separate connectionIds on client and server
+
 //This is the input/player controller for a player's lobby representation
 //Input is given to this script from LobbyManager.cs
 public class PlayerIconController : NetworkBehaviour
@@ -44,6 +48,8 @@ public class PlayerIconController : NetworkBehaviour
     public short playerShip;
     [SyncVar]
     public bool host;
+    [SyncVar]
+    public int connectionId;
 
     private Text nameText;
     private RectTransform rectTransform;
@@ -57,7 +63,9 @@ public class PlayerIconController : NetworkBehaviour
         rectTransform = GetComponent<RectTransform>();
 
         if (isLocalPlayer)
-            CmdPlayerInit(MultiplayerManager.GetLocalClient().connection.connectionId);
+        {
+            CmdPlayerInit(connectionId);
+        }
 
         OnTeamChange(playerTeam);
         OnNameChange(playerName);


### PR DESCRIPTION
Addressed these issues in polish doc:

- No keeping track of death

   - Kills not recorded
- Team selection error
- Tab should not open in Team Select
- Sun and human ship are switched in ship select

MultiplayerManager.cs and PlayerIconController.cs - Networking fixes, first three issues mentioned above.

NetworkHUD.cs - Removed ugly redundant info display in top left, made Tab in-game only

Title Screen scene - Ship select fix.


Identified a pretty huge problem that was affecting a lot of things only when other computers connected to the host with help from Diego Wilde. Most networking errors appeared to stem from this issue, and appear to be fixed now. More testing is needed.